### PR TITLE
Fix minor markup error

### DIFF
--- a/www/partials/home.html
+++ b/www/partials/home.html
@@ -79,8 +79,8 @@
   </div>
 
   <div id="brand">
-    <span class="hidden-xs" >
-      A project of <a href="https://eff.org" class="img-link"><img width="40px" src="/static/{$VERSION}/img/eff-logo.png" alt="EFF logo" /></a> <a href="https://eff.org">Electronic Frontier Foundation</a>
+    <span class="hidden-xs">
+      A project of <a href="https://eff.org" class="img-link"><img width="40" src="/static/{$VERSION}/img/eff-logo.png" alt="EFF logo"></a> <a href="https://eff.org">Electronic Frontier Foundation</a>
     </span>
     <span class="visible-xs">
       A project of <a href="https://eff.org">Electronic Frontier Foundation</a>


### PR DESCRIPTION
`px` is not a valid `width` attribute value. Also removing unnecessary self-closing tag for HTML5 parsers.
